### PR TITLE
Davis Multi Fluid Spawner

### DIFF
--- a/Fluid Simulation/Assets/Resources/Fluids/Beer.asset
+++ b/Fluid Simulation/Assets/Resources/Fluids/Beer.asset
@@ -12,7 +12,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e12b9e3c063da7442bbf0a39f9cba066, type: 3}
   m_Name: Beer
   m_EditorClassIdentifier: 
-  fluidType: 1
+  fluidType: 7
   gravity: -12
   collisionDamping: 0.8
   smoothingRadius: 0.35

--- a/Fluid Simulation/Assets/Scenes/AOS_TESTING.unity
+++ b/Fluid Simulation/Assets/Scenes/AOS_TESTING.unity
@@ -13,7 +13,7 @@ OcclusionCullingSettings:
 --- !u!104 &2
 RenderSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 9
+  serializedVersion: 10
   m_Fog: 0
   m_FogColor: {r: 0.5, g: 0.5, b: 0.5, a: 1}
   m_FogMode: 3
@@ -42,8 +42,8 @@ RenderSettings:
 --- !u!157 &3
 LightmapSettings:
   m_ObjectHideFlags: 0
-  serializedVersion: 12
-  m_GIWorkflowMode: 1
+  serializedVersion: 13
+  m_BakeOnSceneLoad: 0
   m_GISettings:
     serializedVersion: 2
     m_BounceScale: 1
@@ -66,9 +66,6 @@ LightmapSettings:
     m_LightmapParameters: {fileID: 0}
     m_LightmapsBakeMode: 1
     m_TextureCompression: 1
-    m_FinalGather: 0
-    m_FinalGatherFiltering: 1
-    m_FinalGatherRayCount: 256
     m_ReflectionCompression: 2
     m_MixedBakeMode: 2
     m_BakeBackend: 1
@@ -249,18 +246,24 @@ MonoBehaviour:
   m_ItemText: {fileID: 973472362}
   m_ItemImage: {fileID: 0}
   m_Value: 0
+  m_MultiSelect: 0
   m_Options:
     m_Options:
     - m_Text: Option A
       m_Image: {fileID: 0}
+      m_Color: {r: 1, g: 1, b: 1, a: 1}
     - m_Text: Option B
       m_Image: {fileID: 0}
+      m_Color: {r: 1, g: 1, b: 1, a: 1}
     - m_Text: Option C
       m_Image: {fileID: 0}
+      m_Color: {r: 1, g: 1, b: 1, a: 1}
     - m_Text: Option 4
       m_Image: {fileID: 0}
+      m_Color: {r: 1, g: 1, b: 1, a: 1}
     - m_Text: Option 5
       m_Image: {fileID: 0}
+      m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
@@ -503,7 +506,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &61835648
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -517,6 +520,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -658,7 +662,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &86117117
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -672,6 +676,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -935,7 +940,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &153540876
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -949,6 +954,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -1361,15 +1367,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -1436,7 +1444,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &195995834
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -1450,6 +1458,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -1531,6 +1540,59 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 195995832}
   m_CullTransparentMesh: 1
+--- !u!1 &233351979
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 233351981}
+  - component: {fileID: 233351980}
+  m_Layer: 0
+  m_Name: Water Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &233351980
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 233351979}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 0
+  particleCount: 10000
+  initialVelocity: {x: 0, y: 0}
+  spawnCentre: {x: 3.35, y: 0.51}
+  spawnSize: {x: 7, y: 7}
+  jitterStr: 0.025
+  temperature: 0
+  showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
+--- !u!4 &233351981
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 233351979}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.89597684, y: -1.4855696, z: -0.03608622}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &236698510
 GameObject:
   m_ObjectHideFlags: 0
@@ -1926,6 +1988,7 @@ BoxCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 265848396}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -1949,7 +2012,8 @@ BoxCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -1960,7 +2024,6 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
 --- !u!1 &271053315
@@ -2009,12 +2072,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 0
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 3.35, y: 0.51}
   spawnSize: {x: 7, y: 7}
   jitterStr: 0.025
+  temperature: 0
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &271053323
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2085,7 +2151,11 @@ MonoBehaviour:
   selectedFluid: 0
   brushState: 1
   interactionRadius: 3
+  minRadius: 0.25
+  maxRadius: 24
   interactionStrength: 360
+  minStrength: 36
+  maxStrength: 720
   spawnRate: 100
   manuallySelectFluidTypes: 1
   fluidDataArray:
@@ -2224,7 +2294,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &294111655
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -2238,6 +2308,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -2380,7 +2451,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &341326978
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -2394,6 +2465,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -2574,15 +2646,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -2712,7 +2786,6 @@ GameObject:
   m_Component:
   - component: {fileID: 380785146}
   - component: {fileID: 380785142}
-  - component: {fileID: 380785144}
   - component: {fileID: 380785143}
   m_Layer: 0
   m_Name: SimulationAoSCounting
@@ -2735,29 +2808,39 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 1
-  enableHotkeys: 1
+  maxParticles: 10000
+  scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
+  globalEntropyRate: 1
+  roomTemperature: 22
   boundsSize: {x: 34.2, y: 18.6}
   obstacleSize: {x: 0, y: 0}
   obstacleCentre: {x: 0, y: 0}
   edgeType: 0
+  spawnRate: 100
   selectedFluid: 0
   brushState: 1
   interactionRadius: 3
+  minRadius: 0.25
+  maxRadius: 24
   interactionStrength: 360
-  spawnRate: 100
+  minStrength: 36
+  maxStrength: 720
+  smoothingTime: 0.04
+  enableScrolling: 0
+  enableHotkeys: 1
   manuallySelectFluidTypes: 0
   fluidDataArray: []
   compute: {fileID: 7200000, guid: a8dae9eb32a1ce146ad1ac2313a057c1, type: 3}
-  spawner: {fileID: 380785144}
-  display: {fileID: 380785143}
+  spawners:
+  - {fileID: 233351980}
   boxColliders: []
   circleColliders: []
   sourceObjects: []
   drainObjects: []
-  isCPUComputingEnabled: 0
+  thermalBoxes: []
   toggleCPUComputing: 0
-  ThreadBatchSize: 50
+  runCPUGPUEveryFrame: 0
   numCPUKeys: 10
 --- !u!114 &380785143
 MonoBehaviour:
@@ -2806,24 +2889,6 @@ MonoBehaviour:
     m_NumAlphaKeys: 2
   gradientResolution: 64
   velocityDisplayMax: 6.5
---- !u!114 &380785144
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 380785141}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  particleCount: 10000
-  initialVelocity: {x: 0, y: 0}
-  spawnCentre: {x: 3.35, y: 0.51}
-  spawnSize: {x: 7, y: 7}
-  jitterStr: 0.025
-  showSpawnBoundsGizmos: 1
 --- !u!4 &380785146
 Transform:
   m_ObjectHideFlags: 0
@@ -2880,7 +2945,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &385847695
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -2894,6 +2959,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -3087,15 +3153,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -3170,6 +3238,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -3305,15 +3376,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -3567,12 +3640,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 0
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 3.35, y: 0.51}
   spawnSize: {x: 7, y: 7}
   jitterStr: 0.025
+  temperature: 0
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &424244914
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3600,7 +3676,11 @@ MonoBehaviour:
   nearPressureMultiplier: 18
   viscosityStrength: 0.06
   interactionRadius: 3
+  minRadius: 0.25
+  maxRadius: 24
   interactionStrength: 360
+  minStrength: 36
+  maxStrength: 720
   brushState: 1
   currentFluid: {fileID: 0}
   compute: {fileID: 7200000, guid: 1c77ce8de78fddb419ed2d15cae41af0, type: 3}
@@ -3708,15 +3788,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -3803,7 +3885,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &518022419
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -3817,6 +3899,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -4026,15 +4109,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -4208,15 +4293,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -4601,15 +4688,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -4900,6 +4989,7 @@ BoxCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 653271917}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -4923,7 +5013,8 @@ BoxCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -4934,7 +5025,6 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  serializedVersion: 2
   m_Size: {x: 15, y: 40}
   m_EdgeRadius: 0
 --- !u!1 &654793781
@@ -4977,6 +5067,7 @@ BoxCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 654793781}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -5000,7 +5091,8 @@ BoxCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -5011,7 +5103,6 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  serializedVersion: 2
   m_Size: {x: 62, y: 15}
   m_EdgeRadius: 0
 --- !u!1 &657160889
@@ -5246,6 +5337,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -5513,7 +5607,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 925739802}
   m_HandleRect: {fileID: 925739801}
   m_Direction: 0
-  m_Value: 0
+  m_Value: 1
   m_Size: 1
   m_NumberOfSteps: 0
   m_OnValueChanged:
@@ -5692,15 +5786,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -5776,9 +5872,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   smoothingSpeed: 0.2
   enableSmoothing: 1
+  resizable: 0
+  uniformScaling: 0
+  scaleSpeed: 0.1
+  minScale: 0.1
+  maxScale: 5
+  targetScale: {x: 0, y: 0, z: 0}
 --- !u!50 &765292491
 Rigidbody2D:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -5789,8 +5891,8 @@ Rigidbody2D:
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
   m_Mass: 10
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
   m_GravityScale: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -5811,6 +5913,7 @@ BoxCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 765292488}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -5834,7 +5937,8 @@ BoxCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -5845,7 +5949,6 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
 --- !u!1 &767038078
@@ -5938,7 +6041,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &778768984
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -5952,6 +6055,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -6141,6 +6245,7 @@ AudioSource:
   serializedVersion: 4
   OutputAudioMixerGroup: {fileID: 24300002, guid: 05f3bfe96cd1e2840b0da269a5e028c3, type: 2}
   m_audioClip: {fileID: 8300000, guid: f82a2e7ef8b30cd4cb3b4ded59c95143, type: 3}
+  m_Resource: {fileID: 8300000, guid: f82a2e7ef8b30cd4cb3b4ded59c95143, type: 3}
   m_PlayOnAwake: 0
   m_Volume: 0.2
   m_Pitch: 1
@@ -6384,6 +6489,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -6748,15 +6856,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -6974,7 +7084,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &937856885
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -6988,6 +7098,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -7136,6 +7247,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -7278,15 +7392,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -7412,15 +7528,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -7546,15 +7664,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -7758,7 +7878,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &996455021
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -7772,6 +7892,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -8657,7 +8778,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1140956398
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -8671,6 +8792,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -8879,6 +9001,7 @@ BoxCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1169449646}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -8902,7 +9025,8 @@ BoxCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -8913,7 +9037,6 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  serializedVersion: 2
   m_Size: {x: 62, y: 15}
   m_EdgeRadius: 0
 --- !u!1 &1180396755
@@ -9034,7 +9157,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1195866560
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -9048,6 +9171,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -9232,6 +9356,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -9570,15 +9697,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -9777,15 +9906,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -9853,7 +9984,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1330620143
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -9867,6 +9998,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -10078,15 +10210,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -10236,6 +10370,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -10410,7 +10547,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1412855116
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -10424,6 +10561,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -10733,14 +10871,24 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   pauseMenuManager: {fileID: 809702666}
-  simSettingsPanel: {fileID: 99924439}
-  simulation2DGameObject: {fileID: 271053315}
-  informationPanel: {fileID: 981637772}
   audioSource: {fileID: 809702665}
+  audioSource2: {fileID: 0}
+  simSettingsPanel: {fileID: 99924439}
+  informationPanel: {fileID: 981637772}
+  bottomBarParent: {fileID: 0}
+  HideBottomMenuTooltip: {fileID: 0}
   PlayPauseSidebarIcon: {fileID: 2132930927}
   PlayPauseSidebarBG: {fileID: 52673794}
+  HideBottombarIcon: {fileID: 0}
+  HideBottombarBG: {fileID: 0}
   PauseIconImage: {fileID: 21300000, guid: 46670ff3bc6dac94eaeabfe2a316ebdc, type: 3}
   PlayIconImage: {fileID: 21300000, guid: fc75ddf59e12390409d7c04547b531ae, type: 3}
+  brushSettingsMenu: {fileID: 0}
+  allFluidsMenu: {fileID: 0}
+  ObstaclesMenu: {fileID: 0}
+  GasMenu: {fileID: 0}
+  LiquidMenu: {fileID: 0}
+  PowderMenu: {fileID: 0}
 --- !u!114 &1453497372
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -10852,7 +11000,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1458999310
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -10866,6 +11014,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -11044,7 +11193,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1461170660
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -11058,6 +11207,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -11407,15 +11557,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -11484,7 +11636,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1488087622
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -11498,6 +11650,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -11639,7 +11792,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1504652150
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -11653,6 +11806,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -11936,6 +12090,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -12020,6 +12177,9 @@ SpriteRenderer:
   m_ReflectionProbeUsage: 1
   m_RayTracingMode: 0
   m_RayTraceProcedural: 0
+  m_RayTracingAccelStructBuildFlagsOverride: 0
+  m_RayTracingAccelStructBuildFlags: 1
+  m_SmallMeshCulling: 1
   m_RenderingLayerMask: 1
   m_RendererPriority: 0
   m_Materials:
@@ -12157,15 +12317,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -12386,7 +12548,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1568461658
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -12400,6 +12562,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -12705,15 +12868,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -12779,6 +12944,7 @@ BoxCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1616247636}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -12802,7 +12968,8 @@ BoxCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -12813,7 +12980,6 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  serializedVersion: 2
   m_Size: {x: 15, y: 40}
   m_EdgeRadius: 0
 --- !u!1 &1623072512
@@ -13187,15 +13353,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -13396,15 +13564,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -13530,15 +13700,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -13666,15 +13838,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -13800,15 +13974,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -13891,6 +14067,7 @@ CircleCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1716369395}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -13914,9 +14091,9 @@ CircleCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
-  serializedVersion: 2
   m_Radius: 4
 --- !u!114 &1716369399
 MonoBehaviour:
@@ -13932,6 +14109,12 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   smoothingSpeed: 0.2
   enableSmoothing: 1
+  resizable: 0
+  uniformScaling: 0
+  scaleSpeed: 0.1
+  minScale: 0.1
+  maxScale: 5
+  targetScale: {x: 0, y: 0, z: 0}
 --- !u!1 &1748285929
 GameObject:
   m_ObjectHideFlags: 0
@@ -14243,15 +14426,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -14379,15 +14564,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -14455,6 +14642,7 @@ BoxCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1822802306}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -14478,7 +14666,8 @@ BoxCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -14489,7 +14678,6 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
 --- !u!1 &1862353131
@@ -14543,9 +14731,13 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   tmpText: {fileID: 1862353134}
+  fadeBG: {fileID: 0}
   fadeDuration: 0.25
   displayTime: 0.25
-  fadeImmediately: 0
+  fadeInOutImmediately: 0
+  FadeInOnStart: 0
+  moveBGOnStart: 0
+  moveDistance: 50
 --- !u!114 &1862353134
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -14611,15 +14803,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -14901,15 +15095,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -15035,15 +15231,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -15194,15 +15392,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -15438,7 +15638,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &1995633560
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -15452,6 +15652,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -15594,7 +15795,7 @@ RectTransform:
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!95 &2020771242
 Animator:
-  serializedVersion: 5
+  serializedVersion: 7
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -15608,6 +15809,7 @@ Animator:
   m_ApplyRootMotion: 0
   m_LinearVelocityBlending: 0
   m_StabilizeFeet: 0
+  m_AnimatePhysics: 0
   m_WarningMessage: 
   m_HasTransformHierarchy: 1
   m_AllowConstantClipSamplingOptimization: 1
@@ -15996,15 +16198,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 0
+  m_TextWrappingMode: 0
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -16231,15 +16435,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 00000000
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -16628,15 +16834,17 @@ MonoBehaviour:
   m_lineSpacingMax: 0
   m_paragraphSpacing: 0
   m_charWidthMaxAdj: 0
-  m_enableWordWrapping: 1
+  m_TextWrappingMode: 1
   m_wordWrappingRatios: 0.4
   m_overflowMode: 0
   m_linkedTextComponent: {fileID: 0}
   parentLinkedComponent: {fileID: 0}
   m_enableKerning: 1
+  m_ActiveFontFeatures: 6e72656b
   m_enableExtraPadding: 0
   checkPaddingRequired: 0
   m_isRichText: 1
+  m_EmojiFallbackSupport: 1
   m_parseCtrlCharacters: 1
   m_isOrthographic: 1
   m_isCullingEnabled: 0
@@ -16712,9 +16920,15 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   smoothingSpeed: 0.2
   enableSmoothing: 1
+  resizable: 0
+  uniformScaling: 0
+  scaleSpeed: 0.1
+  minScale: 0.1
+  maxScale: 5
+  targetScale: {x: 0, y: 0, z: 0}
 --- !u!50 &2141652552
 Rigidbody2D:
-  serializedVersion: 4
+  serializedVersion: 5
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -16725,8 +16939,8 @@ Rigidbody2D:
   m_UseFullKinematicContacts: 0
   m_UseAutoMass: 0
   m_Mass: 10
-  m_LinearDrag: 0
-  m_AngularDrag: 0.05
+  m_LinearDamping: 0
+  m_AngularDamping: 0.05
   m_GravityScale: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -16747,6 +16961,7 @@ BoxCollider2D:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2141652549}
   m_Enabled: 1
+  serializedVersion: 3
   m_Density: 1
   m_Material: {fileID: 0}
   m_IncludeLayers:
@@ -16770,7 +16985,8 @@ BoxCollider2D:
     m_Bits: 4294967295
   m_IsTrigger: 0
   m_UsedByEffector: 0
-  m_UsedByComposite: 0
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
   m_Offset: {x: 0, y: 0}
   m_SpriteTilingProperty:
     border: {x: 0, y: 0, z: 0, w: 0}
@@ -16781,7 +16997,6 @@ BoxCollider2D:
     drawMode: 0
     adaptiveTiling: 0
   m_AutoTiling: 0
-  serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
 --- !u!1 &2144331110
@@ -16874,3 +17089,4 @@ SceneRoots:
   - {fileID: 424244915}
   - {fileID: 271053318}
   - {fileID: 380785146}
+  - {fileID: 233351981}

--- a/Fluid Simulation/Assets/Scenes/BouncyBallDEMO.unity
+++ b/Fluid Simulation/Assets/Scenes/BouncyBallDEMO.unity
@@ -718,7 +718,6 @@ GameObject:
   m_Component:
   - component: {fileID: 762013223}
   - component: {fileID: 762013222}
-  - component: {fileID: 762013221}
   - component: {fileID: 762013220}
   m_Layer: 0
   m_Name: SimulationAoSCounting with CPU
@@ -742,27 +741,6 @@ MonoBehaviour:
   mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
   shader: {fileID: 4800000, guid: 4b0674bfb9b0d56469ec1da938d50476, type: 3}
   gradientResolution: 64
---- !u!114 &762013221
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 762013219}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  type: 1
-  particleCount: 10240
-  initialVelocity: {x: 0, y: 0}
-  spawnCentre: {x: 0.3, y: -0.2}
-  spawnSize: {x: 7, y: 7}
-  jitterStr: 0.025
-  temperature: 0
-  showSpawnBoundsGizmos: 1
-  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &762013222
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -801,7 +779,8 @@ MonoBehaviour:
   fluidDataArray:
   - {fileID: 11400000, guid: fd36f3ca91602a445a598b2e944c73e5, type: 2}
   compute: {fileID: 7200000, guid: a8dae9eb32a1ce146ad1ac2313a057c1, type: 3}
-  spawner: {fileID: 762013221}
+  spawners:
+  - {fileID: 1110014728}
   boxColliders: []
   circleColliders: []
   sourceObjects: []
@@ -1265,6 +1244,59 @@ BoxCollider2D:
   m_AutoTiling: 0
   m_Size: {x: 62, y: 15}
   m_EdgeRadius: 0
+--- !u!1 &1110014727
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1110014729}
+  - component: {fileID: 1110014728}
+  m_Layer: 0
+  m_Name: Particle Spawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &1110014728
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110014727}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 1
+  particleCount: 10240
+  initialVelocity: {x: 0, y: 0}
+  spawnCentre: {x: 0.3, y: -0.2}
+  spawnSize: {x: 7, y: 7}
+  jitterStr: 0.025
+  temperature: 0
+  showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
+--- !u!4 &1110014729
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1110014727}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.89597684, y: -1.4855696, z: -0.03608622}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1419766691
 GameObject:
   m_ObjectHideFlags: 0
@@ -1435,7 +1467,8 @@ MonoBehaviour:
   - {fileID: 11400000, guid: feb8075e7e5787d4dbe0b2d994dd13db, type: 2}
   - {fileID: 11400000, guid: fd36f3ca91602a445a598b2e944c73e5, type: 2}
   compute: {fileID: 7200000, guid: 1b27e55b66edb094bbb191e63a6a5359, type: 3}
-  spawner: {fileID: 1430943822}
+  spawners:
+  - {fileID: 1110014728}
   boxColliders:
   - {fileID: 338494981}
   - {fileID: 560968175}
@@ -3631,3 +3664,4 @@ SceneRoots:
   - {fileID: 2137391897}
   - {fileID: 1466571978}
   - {fileID: 762013223}
+  - {fileID: 1110014729}

--- a/Fluid Simulation/Assets/Scenes/BouncyBallDEMO.unity
+++ b/Fluid Simulation/Assets/Scenes/BouncyBallDEMO.unity
@@ -755,6 +755,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 1
+  maxParticles: 10000
   scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
@@ -1441,6 +1442,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 1
+  maxParticles: 10000
   scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1

--- a/Fluid Simulation/Assets/Scenes/BouncyBallDEMO.unity
+++ b/Fluid Simulation/Assets/Scenes/BouncyBallDEMO.unity
@@ -358,6 +358,7 @@ MonoBehaviour:
   scaleSpeed: 0.1
   minScale: 1
   maxScale: 18
+  targetScale: {x: 0, y: 0, z: 0}
 --- !u!50 &338494979
 Rigidbody2D:
   serializedVersion: 5
@@ -618,6 +619,7 @@ MonoBehaviour:
   scaleSpeed: 0.1
   minScale: 1
   maxScale: 18
+  targetScale: {x: 0, y: 0, z: 0}
 --- !u!50 &560968173
 Rigidbody2D:
   serializedVersion: 5
@@ -752,12 +754,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 1
   particleCount: 10240
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 0.3, y: -0.2}
   spawnSize: {x: 7, y: 7}
   jitterStr: 0.025
+  temperature: 0
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &762013222
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -772,7 +777,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 1
-  enableHotkeys: 1
+  scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
   roomTemperature: 22
@@ -784,11 +789,14 @@ MonoBehaviour:
   selectedFluid: 0
   brushState: 1
   interactionRadius: 3
-  interactionStrength: 360
   minRadius: 0.25
   maxRadius: 24
+  interactionStrength: 360
+  minStrength: 36
+  maxStrength: 720
   smoothingTime: 0.04
   enableScrolling: 1
+  enableHotkeys: 1
   manuallySelectFluidTypes: 1
   fluidDataArray:
   - {fileID: 11400000, guid: fd36f3ca91602a445a598b2e944c73e5, type: 2}
@@ -800,6 +808,7 @@ MonoBehaviour:
   drainObjects: []
   thermalBoxes: []
   toggleCPUComputing: 0
+  runCPUGPUEveryFrame: 0
   numCPUKeys: 10
 --- !u!4 &762013223
 Transform:
@@ -1362,12 +1371,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 0
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 3.35, y: 0.51}
   spawnSize: {x: 7, y: 7}
   jitterStr: 0.025
+  temperature: 0
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!4 &1430943824
 Transform:
   m_ObjectHideFlags: 0
@@ -1397,7 +1409,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 1
-  enableHotkeys: 1
+  scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
   roomTemperature: 22
@@ -1409,11 +1421,14 @@ MonoBehaviour:
   selectedFluid: 0
   brushState: 1
   interactionRadius: 3
-  interactionStrength: 360
   minRadius: 0.25
   maxRadius: 24
+  interactionStrength: 360
+  minStrength: 36
+  maxStrength: 720
   smoothingTime: 0.04
   enableScrolling: 0
+  enableHotkeys: 1
   manuallySelectFluidTypes: 1
   updateFluidsEveryFrame: 0
   fluidDataArray:
@@ -1485,6 +1500,7 @@ MonoBehaviour:
   scaleSpeed: 0.1
   minScale: 1
   maxScale: 18
+  targetScale: {x: 0, y: 0, z: 0}
 --- !u!50 &1466571976
 Rigidbody2D:
   serializedVersion: 5
@@ -1575,6 +1591,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b12e0ae21360f174a9bbc5a497634589, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  segments: 50
 --- !u!120 &1466571980
 LineRenderer:
   serializedVersion: 2
@@ -2220,6 +2237,7 @@ MonoBehaviour:
   scaleSpeed: 0.1
   minScale: 1
   maxScale: 18
+  targetScale: {x: 0, y: 0, z: 0}
 --- !u!50 &2137391895
 Rigidbody2D:
   serializedVersion: 5
@@ -2274,6 +2292,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b12e0ae21360f174a9bbc5a497634589, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  segments: 50
 --- !u!120 &2137391899
 LineRenderer:
   serializedVersion: 2
@@ -2839,6 +2858,30 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 2543386145689813042, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
       propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3273066276391849151, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3273066276391849151, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_AnchorMin.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3273066276391849151, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3273066276391849151, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3273066276391849151, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 3273066276391849151, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 3576416761000970758, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}

--- a/Fluid Simulation/Assets/Scenes/Level_1.unity
+++ b/Fluid Simulation/Assets/Scenes/Level_1.unity
@@ -736,12 +736,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 0
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 0, y: -6.02}
   spawnSize: {x: 30, y: 5}
   jitterStr: 0.025
+  temperature: 0
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &271053323
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2706,12 +2709,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 0
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 0, y: -6.02}
   spawnSize: {x: 30, y: 5}
   jitterStr: 0.025
+  temperature: 0
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &1173401525
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2727,7 +2733,6 @@ MonoBehaviour:
   timeScale: 1
   fixedTimeStep: 0
   scanForObstaclesOnStart: 1
-  enableHotkeys: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
   roomTemperature: 22
@@ -2746,6 +2751,7 @@ MonoBehaviour:
   maxStrength: 720
   smoothingTime: 0.04
   enableScrolling: 1
+  enableHotkeys: 1
   manuallySelectFluidTypes: 1
   fluidDataArray:
   - {fileID: 11400000, guid: 423f11e3028cd9f41a43da9a7715b357, type: 2}
@@ -3019,12 +3025,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 7
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 0, y: -6.02}
   spawnSize: {x: 30, y: 5}
   jitterStr: 0.025
+  temperature: 10
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &1396291943
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3040,7 +3049,6 @@ MonoBehaviour:
   timeScale: 1
   fixedTimeStep: 1
   scanForObstaclesOnStart: 0
-  enableHotkeys: 0
   iterationsPerFrame: 3
   globalEntropyRate: 1
   roomTemperature: 22
@@ -3059,6 +3067,7 @@ MonoBehaviour:
   maxStrength: 720
   smoothingTime: 0.04
   enableScrolling: 1
+  enableHotkeys: 0
   manuallySelectFluidTypes: 1
   updateFluidsEveryFrame: 0
   fluidDataArray:

--- a/Fluid Simulation/Assets/Scenes/Level_1.unity
+++ b/Fluid Simulation/Assets/Scenes/Level_1.unity
@@ -2688,7 +2688,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1173401526}
   - component: {fileID: 1173401525}
-  - component: {fileID: 1173401524}
   - component: {fileID: 1173401528}
   m_Layer: 0
   m_Name: SimulationAoSCounting CPU
@@ -2697,27 +2696,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!114 &1173401524
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1173401522}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  type: 0
-  particleCount: 10000
-  initialVelocity: {x: 0, y: 0}
-  spawnCentre: {x: 0, y: -6.02}
-  spawnSize: {x: 30, y: 5}
-  jitterStr: 0.025
-  temperature: 0
-  showSpawnBoundsGizmos: 1
-  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &1173401525
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2756,7 +2734,8 @@ MonoBehaviour:
   fluidDataArray:
   - {fileID: 11400000, guid: 423f11e3028cd9f41a43da9a7715b357, type: 2}
   compute: {fileID: 7200000, guid: a8dae9eb32a1ce146ad1ac2313a057c1, type: 3}
-  spawner: {fileID: 1173401524}
+  spawners:
+  - {fileID: 1540588521}
   boxColliders:
   - {fileID: 1163845349}
   - {fileID: 2123023228}
@@ -2989,7 +2968,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1396291944}
   - component: {fileID: 1396291943}
-  - component: {fileID: 1396291942}
   - component: {fileID: 1396291941}
   m_Layer: 0
   m_Name: SimulationAoSCounting
@@ -3013,27 +2991,6 @@ MonoBehaviour:
   mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
   shader: {fileID: 4800000, guid: 4b0674bfb9b0d56469ec1da938d50476, type: 3}
   gradientResolution: 64
---- !u!114 &1396291942
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1396291940}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  type: 7
-  particleCount: 10000
-  initialVelocity: {x: 0, y: 0}
-  spawnCentre: {x: 0, y: -6.02}
-  spawnSize: {x: 30, y: 5}
-  jitterStr: 0.025
-  temperature: 10
-  showSpawnBoundsGizmos: 1
-  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &1396291943
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3073,7 +3030,8 @@ MonoBehaviour:
   fluidDataArray:
   - {fileID: 11400000, guid: 423f11e3028cd9f41a43da9a7715b357, type: 2}
   compute: {fileID: 7200000, guid: 1b27e55b66edb094bbb191e63a6a5359, type: 3}
-  spawner: {fileID: 1396291942}
+  spawners:
+  - {fileID: 1540588521}
   boxColliders:
   - {fileID: 1163845349}
   - {fileID: 2123023228}
@@ -3974,6 +3932,59 @@ PrefabInstance:
     m_AddedGameObjects: []
     m_AddedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+--- !u!1 &1540588520
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1540588522}
+  - component: {fileID: 1540588521}
+  m_Layer: 0
+  m_Name: Beer Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 2147483647
+  m_IsActive: 1
+--- !u!114 &1540588521
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1540588520}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 7
+  particleCount: 10000
+  initialVelocity: {x: 0, y: 0}
+  spawnCentre: {x: 0, y: -6.02}
+  spawnSize: {x: 30, y: 5}
+  jitterStr: 0.025
+  temperature: 10
+  showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
+--- !u!4 &1540588522
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1540588520}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.89597684, y: -1.4855696, z: -0.03608622}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1545461170
 GameObject:
   m_ObjectHideFlags: 0
@@ -5223,3 +5234,4 @@ SceneRoots:
   - {fileID: 2003172739}
   - {fileID: 914899443}
   - {fileID: 791139166}
+  - {fileID: 1540588522}

--- a/Fluid Simulation/Assets/Scenes/Level_1.unity
+++ b/Fluid Simulation/Assets/Scenes/Level_1.unity
@@ -2710,6 +2710,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 0
+  maxParticles: 10000
   scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
@@ -3005,6 +3006,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 1
+  maxParticles: 10000
   scanForObstaclesOnStart: 0
   iterationsPerFrame: 3
   globalEntropyRate: 1

--- a/Fluid Simulation/Assets/Scenes/Level_2.unity
+++ b/Fluid Simulation/Assets/Scenes/Level_2.unity
@@ -1017,7 +1017,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   type: 1
-  particleCount: 16384
+  particleCount: 16000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 0, y: 500}
   spawnSize: {x: 7, y: 7}
@@ -2024,6 +2024,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 1
+  maxParticles: 16000
   scanForObstaclesOnStart: 0
   iterationsPerFrame: 3
   globalEntropyRate: 1
@@ -5943,6 +5944,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 0
+  maxParticles: 16000
   scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
@@ -5965,7 +5967,7 @@ MonoBehaviour:
   enableHotkeys: 1
   manuallySelectFluidTypes: 1
   fluidDataArray:
-  - {fileID: 11400000, guid: 423f11e3028cd9f41a43da9a7715b357, type: 2}
+  - {fileID: 11400000, guid: c32291ce16f51cf448f73f38171e1ddc, type: 2}
   compute: {fileID: 7200000, guid: a8dae9eb32a1ce146ad1ac2313a057c1, type: 3}
   spawners:
   - {fileID: 171782988}

--- a/Fluid Simulation/Assets/Scenes/Level_2.unity
+++ b/Fluid Simulation/Assets/Scenes/Level_2.unity
@@ -987,6 +987,59 @@ Transform:
   m_Children: []
   m_Father: {fileID: 0}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &171782987
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 171782989}
+  - component: {fileID: 171782988}
+  m_Layer: 0
+  m_Name: Particle Spawner
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &171782988
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 171782987}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 1
+  particleCount: 16384
+  initialVelocity: {x: 0, y: 0}
+  spawnCentre: {x: 0, y: 500}
+  spawnSize: {x: 7, y: 7}
+  jitterStr: 0.025
+  temperature: 0
+  showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
+--- !u!4 &171782989
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 171782987}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.89597684, y: -1.4855696, z: -0.03608622}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &208621299
 GameObject:
   m_ObjectHideFlags: 0
@@ -1636,12 +1689,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 0
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 0, y: -6.02}
   spawnSize: {x: 30, y: 5}
   jitterStr: 0.025
+  temperature: 0
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &271053323
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1931,7 +1987,6 @@ GameObject:
   m_Component:
   - component: {fileID: 402679193}
   - component: {fileID: 402679192}
-  - component: {fileID: 402679191}
   - component: {fileID: 402679190}
   m_Layer: 0
   m_Name: SimulationAoSCounting
@@ -1955,24 +2010,6 @@ MonoBehaviour:
   mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
   shader: {fileID: 4800000, guid: 4b0674bfb9b0d56469ec1da938d50476, type: 3}
   gradientResolution: 64
---- !u!114 &402679191
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 402679189}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  particleCount: 16384
-  initialVelocity: {x: 0, y: 0}
-  spawnCentre: {x: 0, y: 500}
-  spawnSize: {x: 7, y: 7}
-  jitterStr: 0.025
-  showSpawnBoundsGizmos: 1
 --- !u!114 &402679192
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1988,7 +2025,6 @@ MonoBehaviour:
   timeScale: 1
   fixedTimeStep: 1
   scanForObstaclesOnStart: 0
-  enableHotkeys: 0
   iterationsPerFrame: 3
   globalEntropyRate: 1
   roomTemperature: 22
@@ -2007,12 +2043,14 @@ MonoBehaviour:
   maxStrength: 720
   smoothingTime: 0.04
   enableScrolling: 0
+  enableHotkeys: 0
   manuallySelectFluidTypes: 1
   updateFluidsEveryFrame: 0
   fluidDataArray:
   - {fileID: 11400000, guid: c32291ce16f51cf448f73f38171e1ddc, type: 2}
   compute: {fileID: 7200000, guid: 1b27e55b66edb094bbb191e63a6a5359, type: 3}
-  spawner: {fileID: 402679191}
+  spawners:
+  - {fileID: 171782988}
   boxColliders:
   - {fileID: 1090131025}
   - {fileID: 468671236}
@@ -5883,7 +5921,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1173401526}
   - component: {fileID: 1173401525}
-  - component: {fileID: 1173401524}
   - component: {fileID: 1173401528}
   m_Layer: 0
   m_Name: SimulationAoSCounting CPU
@@ -5892,24 +5929,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!114 &1173401524
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1173401522}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  particleCount: 10000
-  initialVelocity: {x: 0, y: 0}
-  spawnCentre: {x: 0, y: -6.02}
-  spawnSize: {x: 30, y: 5}
-  jitterStr: 0.025
-  showSpawnBoundsGizmos: 1
 --- !u!114 &1173401525
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -5925,7 +5944,6 @@ MonoBehaviour:
   timeScale: 1
   fixedTimeStep: 0
   scanForObstaclesOnStart: 1
-  enableHotkeys: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
   roomTemperature: 22
@@ -5944,11 +5962,13 @@ MonoBehaviour:
   maxStrength: 720
   smoothingTime: 0.04
   enableScrolling: 1
+  enableHotkeys: 1
   manuallySelectFluidTypes: 1
   fluidDataArray:
   - {fileID: 11400000, guid: 423f11e3028cd9f41a43da9a7715b357, type: 2}
   compute: {fileID: 7200000, guid: a8dae9eb32a1ce146ad1ac2313a057c1, type: 3}
-  spawner: {fileID: 1173401524}
+  spawners:
+  - {fileID: 171782988}
   boxColliders:
   - {fileID: 0}
   - {fileID: 0}
@@ -11971,3 +11991,4 @@ SceneRoots:
   - {fileID: 609287617}
   - {fileID: 797937581}
   - {fileID: 1844744036}
+  - {fileID: 171782989}

--- a/Fluid Simulation/Assets/Scenes/Main Menu.unity
+++ b/Fluid Simulation/Assets/Scenes/Main Menu.unity
@@ -4258,6 +4258,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 0
+  maxParticles: 10000
   scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1

--- a/Fluid Simulation/Assets/Scenes/Main Menu.unity
+++ b/Fluid Simulation/Assets/Scenes/Main Menu.unity
@@ -2124,12 +2124,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 1
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 0, y: 0.51}
   spawnSize: {x: 7, y: 7}
   jitterStr: 0.025
+  temperature: 22
   showSpawnBoundsGizmos: 0
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &992768939
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -2157,7 +2160,11 @@ MonoBehaviour:
   nearPressureMultiplier: 18
   viscosityStrength: 0.06
   interactionRadius: 3
+  minRadius: 0.25
+  maxRadius: 24
   interactionStrength: 360
+  minStrength: 36
+  maxStrength: 720
   brushState: 1
   currentFluid: {fileID: 0}
   compute: {fileID: 7200000, guid: 1c77ce8de78fddb419ed2d15cae41af0, type: 3}
@@ -4197,12 +4204,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 1
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 0, y: 0.51}
   spawnSize: {x: 7, y: 7}
   jitterStr: 0.025
+  temperature: 22
   showSpawnBoundsGizmos: 0
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &2070748596
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4217,7 +4227,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 0
-  enableHotkeys: 0
+  scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
   roomTemperature: 22
@@ -4229,11 +4239,14 @@ MonoBehaviour:
   selectedFluid: 0
   brushState: 1
   interactionRadius: 3
-  interactionStrength: 360
   minRadius: 0.25
   maxRadius: 24
+  interactionStrength: 360
+  minStrength: 36
+  maxStrength: 720
   smoothingTime: 0.04
   enableScrolling: 0
+  enableHotkeys: 0
   manuallySelectFluidTypes: 1
   fluidDataArray:
   - {fileID: 11400000, guid: fd36f3ca91602a445a598b2e944c73e5, type: 2}
@@ -4244,8 +4257,8 @@ MonoBehaviour:
   sourceObjects: []
   drainObjects: []
   thermalBoxes: []
-  isCPUComputingEnabled: 0
   toggleCPUComputing: 0
+  runCPUGPUEveryFrame: 0
   numCPUKeys: 10
 --- !u!4 &2070748597
 Transform:

--- a/Fluid Simulation/Assets/Scenes/Main Menu.unity
+++ b/Fluid Simulation/Assets/Scenes/Main Menu.unity
@@ -1292,6 +1292,59 @@ MonoBehaviour:
   easeType: 27
   animateOnEnable: 0
   delayAfterSceneLoad: 0.1
+--- !u!1 &784062419
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 784062421}
+  - component: {fileID: 784062420}
+  m_Layer: 0
+  m_Name: WaterSpawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &784062420
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 784062419}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 1
+  particleCount: 10000
+  initialVelocity: {x: 0, y: 0}
+  spawnCentre: {x: 0, y: 0.51}
+  spawnSize: {x: 7, y: 7}
+  jitterStr: 0.025
+  temperature: 22
+  showSpawnBoundsGizmos: 0
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
+--- !u!4 &784062421
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 784062419}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.89597684, y: -1.4855696, z: -0.03608622}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &854230216
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -4183,7 +4236,6 @@ GameObject:
   m_Component:
   - component: {fileID: 2070748597}
   - component: {fileID: 2070748596}
-  - component: {fileID: 2070748595}
   - component: {fileID: 2070748598}
   m_Layer: 0
   m_Name: SimulationAoSCounting w CPU
@@ -4192,27 +4244,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &2070748595
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 2070748593}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  type: 1
-  particleCount: 10000
-  initialVelocity: {x: 0, y: 0}
-  spawnCentre: {x: 0, y: 0.51}
-  spawnSize: {x: 7, y: 7}
-  jitterStr: 0.025
-  temperature: 22
-  showSpawnBoundsGizmos: 0
-  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &2070748596
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -4251,7 +4282,8 @@ MonoBehaviour:
   fluidDataArray:
   - {fileID: 11400000, guid: fd36f3ca91602a445a598b2e944c73e5, type: 2}
   compute: {fileID: 7200000, guid: a8dae9eb32a1ce146ad1ac2313a057c1, type: 3}
-  spawner: {fileID: 2070748595}
+  spawners:
+  - {fileID: 784062420}
   boxColliders: []
   circleColliders: []
   sourceObjects: []
@@ -4760,3 +4792,4 @@ SceneRoots:
   - {fileID: 1773495312}
   - {fileID: 69762892}
   - {fileID: 1973671213}
+  - {fileID: 784062421}

--- a/Fluid Simulation/Assets/Scenes/Sandbox.unity
+++ b/Fluid Simulation/Assets/Scenes/Sandbox.unity
@@ -829,7 +829,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   type: 1
-  particleCount: 10000
+  particleCount: 1
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 0, y: 0}
   spawnSize: {x: 13, y: 6}
@@ -882,7 +882,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   type: 2
-  particleCount: 5000
+  particleCount: 1
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 10, y: 0}
   spawnSize: {x: 5, y: 5}

--- a/Fluid Simulation/Assets/Scenes/Sandbox.unity
+++ b/Fluid Simulation/Assets/Scenes/Sandbox.unity
@@ -587,6 +587,7 @@ MonoBehaviour:
   fixedTimeStep: 0
   maxParticles: 16000
   scanForObstaclesOnStart: 1
+  scanForParticleSpawnersOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
   roomTemperature: 25
@@ -1759,6 +1760,7 @@ MonoBehaviour:
   fixedTimeStep: 0
   maxParticles: 16000
   scanForObstaclesOnStart: 1
+  scanForParticleSpawnersOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
   roomTemperature: 22
@@ -1794,9 +1796,7 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 43826162adaa5b9428c27e25092546a9, type: 2}
   - {fileID: 11400000, guid: 7be9d18a448d11e49a0719bb3db60b94, type: 2}
   compute: {fileID: 7200000, guid: 1b27e55b66edb094bbb191e63a6a5359, type: 3}
-  spawners:
-  - {fileID: 849118680}
-  - {fileID: 929574466}
+  spawners: []
   boxColliders: []
   circleColliders: []
   sourceObjects: []

--- a/Fluid Simulation/Assets/Scenes/Sandbox.unity
+++ b/Fluid Simulation/Assets/Scenes/Sandbox.unity
@@ -585,7 +585,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 0
-  maxParticles: 0
+  maxParticles: 16000
   scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
@@ -1125,7 +1125,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 1
-  maxParticles: 0
+  maxParticles: 16000
   scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1

--- a/Fluid Simulation/Assets/Scenes/Sandbox.unity
+++ b/Fluid Simulation/Assets/Scenes/Sandbox.unity
@@ -404,12 +404,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 0
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 3.35, y: 0.51}
   spawnSize: {x: 7, y: 7}
   jitterStr: 0.025
+  temperature: 0
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &271053323
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -581,12 +584,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 0
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 3.35, y: 0.51}
   spawnSize: {x: 7, y: 7}
   jitterStr: 0.025
+  temperature: 0
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &489172454
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1031,12 +1037,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 0
   particleCount: 16384
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 3.35, y: 0.51}
   spawnSize: {x: 7, y: 7}
   jitterStr: 0.025
+  temperature: 0
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &981710269
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1196,12 +1205,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 0
   particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 3.35, y: 0.51}
   spawnSize: {x: 7, y: 7}
   jitterStr: 0.025
+  temperature: 0
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &1080519537
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1661,12 +1673,15 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  type: 1
   particleCount: 16384
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 0, y: 0}
   spawnSize: {x: 13, y: 6}
   jitterStr: 0.025
+  temperature: 22
   showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!4 &1430943824
 Transform:
   m_ObjectHideFlags: 0

--- a/Fluid Simulation/Assets/Scenes/Sandbox.unity
+++ b/Fluid Simulation/Assets/Scenes/Sandbox.unity
@@ -1037,13 +1037,13 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  type: 0
+  type: 1
   particleCount: 16384
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 3.35, y: 0.51}
   spawnSize: {x: 7, y: 7}
   jitterStr: 0.025
-  temperature: 0
+  temperature: 22
   showSpawnBoundsGizmos: 1
   wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &981710269

--- a/Fluid Simulation/Assets/Scenes/Sandbox.unity
+++ b/Fluid Simulation/Assets/Scenes/Sandbox.unity
@@ -548,7 +548,6 @@ GameObject:
   m_Component:
   - component: {fileID: 489172455}
   - component: {fileID: 489172454}
-  - component: {fileID: 489172453}
   - component: {fileID: 489172452}
   m_Layer: 0
   m_Name: SimulationAoSCounting w SinglePass Shader
@@ -572,27 +571,6 @@ MonoBehaviour:
   mesh: {fileID: 10210, guid: 0000000000000000e000000000000000, type: 0}
   shader: {fileID: 4800000, guid: bfa6cbae1ccaae443a7d284803c09d26, type: 3}
   gradientResolution: 64
---- !u!114 &489172453
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 489172451}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  type: 0
-  particleCount: 10000
-  initialVelocity: {x: 0, y: 0}
-  spawnCentre: {x: 3.35, y: 0.51}
-  spawnSize: {x: 7, y: 7}
-  jitterStr: 0.025
-  temperature: 0
-  showSpawnBoundsGizmos: 1
-  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &489172454
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -635,7 +613,9 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 4155bda3e8ce04741a5ac0b11a37e7e8, type: 2}
   - {fileID: 11400000, guid: ddd95d8ea0710794d95d7071c2c28a3e, type: 2}
   compute: {fileID: 7200000, guid: 1b27e55b66edb094bbb191e63a6a5359, type: 3}
-  spawner: {fileID: 489172453}
+  spawners:
+  - {fileID: 849118680}
+  - {fileID: 929574466}
   boxColliders: []
   circleColliders: []
   sourceObjects: []
@@ -813,6 +793,112 @@ Transform:
   serializedVersion: 2
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &849118679
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 849118681}
+  - component: {fileID: 849118680}
+  m_Layer: 0
+  m_Name: Water Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &849118680
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849118679}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 1
+  particleCount: 16384
+  initialVelocity: {x: 0, y: 0}
+  spawnCentre: {x: 0, y: 0}
+  spawnSize: {x: 13, y: 6}
+  jitterStr: 0.025
+  temperature: 22
+  showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
+--- !u!4 &849118681
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 849118679}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.89597684, y: -1.4855696, z: -0.03608622}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_ConstrainProportionsScale: 0
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &929574465
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 929574467}
+  - component: {fileID: 929574466}
+  m_Layer: 0
+  m_Name: Steam Spawn
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!114 &929574466
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 929574465}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  type: 2
+  particleCount: 5000
+  initialVelocity: {x: 0, y: 0}
+  spawnCentre: {x: 10, y: 0}
+  spawnSize: {x: 5, y: 5}
+  jitterStr: 0.025
+  temperature: 200
+  showSpawnBoundsGizmos: 1
+  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
+--- !u!4 &929574467
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 929574465}
+  serializedVersion: 2
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.89597684, y: -1.4855696, z: -0.03608622}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
   m_Children: []
@@ -1016,7 +1102,6 @@ GameObject:
   m_Component:
   - component: {fileID: 981710270}
   - component: {fileID: 981710269}
-  - component: {fileID: 981710268}
   - component: {fileID: 981710271}
   m_Layer: 0
   m_Name: SimulationAoSCounting with CPU
@@ -1025,27 +1110,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 0
---- !u!114 &981710268
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 981710266}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  type: 1
-  particleCount: 16384
-  initialVelocity: {x: 0, y: 0}
-  spawnCentre: {x: 3.35, y: 0.51}
-  spawnSize: {x: 7, y: 7}
-  jitterStr: 0.025
-  temperature: 22
-  showSpawnBoundsGizmos: 1
-  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!114 &981710269
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1088,7 +1152,9 @@ MonoBehaviour:
   - {fileID: 11400000, guid: ddd95d8ea0710794d95d7071c2c28a3e, type: 2}
   - {fileID: 11400000, guid: f24359e82133950498e8c474b135750d, type: 2}
   compute: {fileID: 7200000, guid: a8dae9eb32a1ce146ad1ac2313a057c1, type: 3}
-  spawner: {fileID: 981710268}
+  spawners:
+  - {fileID: 849118680}
+  - {fileID: 929574466}
   boxColliders: []
   circleColliders: []
   sourceObjects: []
@@ -1652,7 +1718,6 @@ GameObject:
   m_Component:
   - component: {fileID: 1430943824}
   - component: {fileID: 1430943825}
-  - component: {fileID: 1430943822}
   - component: {fileID: 1430943826}
   m_Layer: 0
   m_Name: SimulationAoSCounting
@@ -1661,27 +1726,6 @@ GameObject:
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
   m_IsActive: 1
---- !u!114 &1430943822
-MonoBehaviour:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 1430943820}
-  m_Enabled: 1
-  m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 895837b52d5fc53409ded3589d4da696, type: 3}
-  m_Name: 
-  m_EditorClassIdentifier: 
-  type: 1
-  particleCount: 16384
-  initialVelocity: {x: 0, y: 0}
-  spawnCentre: {x: 0, y: 0}
-  spawnSize: {x: 13, y: 6}
-  jitterStr: 0.025
-  temperature: 22
-  showSpawnBoundsGizmos: 1
-  wireFrameColor: {r: 1, g: 1, b: 0, a: 0.5}
 --- !u!4 &1430943824
 Transform:
   m_ObjectHideFlags: 0
@@ -1747,7 +1791,9 @@ MonoBehaviour:
   - {fileID: 11400000, guid: 43826162adaa5b9428c27e25092546a9, type: 2}
   - {fileID: 11400000, guid: 7be9d18a448d11e49a0719bb3db60b94, type: 2}
   compute: {fileID: 7200000, guid: 1b27e55b66edb094bbb191e63a6a5359, type: 3}
-  spawner: {fileID: 1430943822}
+  spawners:
+  - {fileID: 849118680}
+  - {fileID: 929574466}
   boxColliders: []
   circleColliders: []
   sourceObjects: []
@@ -2699,6 +2745,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 2003720409719654229, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2003720409719654229, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2003720409719654229, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_SizeDelta.x
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 2109621059557760878, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
       propertyPath: m_SizeDelta.y
       value: 0
@@ -3079,6 +3137,18 @@ PrefabInstance:
       propertyPath: m_AnchoredPosition.y
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 8255019471513744908, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_AnchorMax.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8255019471513744908, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_AnchorMax.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 8255019471513744908, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
+      propertyPath: m_SizeDelta.y
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 8468455024000708786, guid: dd46875c7ac63d84e8674c7e5fd021bd, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0
@@ -3207,3 +3277,5 @@ SceneRoots:
   - {fileID: 1497315419}
   - {fileID: 1526596367}
   - {fileID: 638810972}
+  - {fileID: 849118681}
+  - {fileID: 929574467}

--- a/Fluid Simulation/Assets/Scenes/Sandbox.unity
+++ b/Fluid Simulation/Assets/Scenes/Sandbox.unity
@@ -585,6 +585,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 0
+  maxParticles: 0
   scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
@@ -828,7 +829,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   type: 1
-  particleCount: 16384
+  particleCount: 10000
   initialVelocity: {x: 0, y: 0}
   spawnCentre: {x: 0, y: 0}
   spawnSize: {x: 13, y: 6}
@@ -1124,6 +1125,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 1
+  maxParticles: 0
   scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1
@@ -1755,6 +1757,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   timeScale: 1
   fixedTimeStep: 0
+  maxParticles: 16000
   scanForObstaclesOnStart: 1
   iterationsPerFrame: 3
   globalEntropyRate: 1

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/ParticleSpawner.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/ParticleSpawner.cs
@@ -72,7 +72,7 @@ public class ParticleSpawner : MonoBehaviour
         }
     }
 
-    void OnDrawGizmos()
+    public void OnDrawGizmos()
     {
         if (!showSpawnBoundsGizmos || Application.isPlaying) return;
 

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/ParticleSpawner.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/ParticleSpawner.cs
@@ -72,6 +72,39 @@ public class ParticleSpawner : MonoBehaviour
         }
     }
 
+    // Gets ParticleSpawnData to fill scene with Disabled particles
+    static public ParticleSpawnData GetSceneFill(int pCount, Vector2 sceneSize)
+    {
+        ParticleSpawnData data = new ParticleSpawnData(FluidType.Disabled, pCount, 0);
+
+        var rng = new Unity.Mathematics.Random(42);
+
+        float2 s = sceneSize;
+        int numX = Mathf.CeilToInt(Mathf.Sqrt(s.x / s.y * pCount + (s.x - s.y) * (s.x - s.y) / (4 * s.y * s.y)) - (s.x - s.y) / (2 * s.y));
+        int numY = Mathf.CeilToInt(pCount / (float)numX);
+        int i = 0;
+
+        for (int y = 0; y < numY; y++)
+        {
+            for (int x = 0; x < numX; x++)
+            {
+                if (i >= pCount) break;
+
+                float tx = numX <= 1 ? 0.5f : x / (numX - 1f);
+                float ty = numY <= 1 ? 0.5f : y / (numY - 1f);
+
+                float angle = (float)rng.NextDouble() * 3.14f * 2;
+                Vector2 dir = new Vector2(Mathf.Cos(angle), Mathf.Sin(angle));
+                Vector2 jitter = dir * 0;
+                data.positions[i] = new Vector2((tx - 0.5f) * sceneSize.x, (ty - 0.5f) * sceneSize.y) + jitter;
+                data.velocities[i] = 0;
+                i++;
+            }
+        }
+
+        return data;
+    }
+
     public void OnDrawGizmos()
     {
         if (!showSpawnBoundsGizmos || Application.isPlaying) return;

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/ParticleSpawner.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/ParticleSpawner.cs
@@ -3,17 +3,22 @@ using Unity.Mathematics;
 
 public class ParticleSpawner : MonoBehaviour
 {
+    [Header("Spawner Settings")]
+    public FluidType type;
     public int particleCount;
-
     public Vector2 initialVelocity;
     public Vector2 spawnCentre;
     public Vector2 spawnSize;
     public float jitterStr;
+    public float temperature;
+
+    [Header("Debug")]
     public bool showSpawnBoundsGizmos;
+    public Color wireFrameColor = new(1, 1, 0, 0.5f);
 
     public ParticleSpawnData GetSpawnData()
     {
-        ParticleSpawnData data = new ParticleSpawnData(particleCount);
+        ParticleSpawnData data = new ParticleSpawnData(type, particleCount, temperature);
         var rng = new Unity.Mathematics.Random(42);
 
         float2 s = spawnSize;
@@ -42,24 +47,36 @@ public class ParticleSpawner : MonoBehaviour
         return data;
     }
 
+    // Only defines fluid data. Spawn position and size of spawn area determined by ParticleSpawner.
     public struct ParticleSpawnData
     {
+        public FluidType type;
         public float2[] positions;
         public float2[] velocities;
+        public float temperature;
 
-        public ParticleSpawnData(int num)
+        public ParticleSpawnData(int num) // Old call, for compatibility
         {
+            this.type = FluidType.Water;
             positions = new float2[num];
             velocities = new float2[num];
+            this.temperature = 22f;
+        }
+
+        public ParticleSpawnData(FluidType type, int num, float temperature)
+        {
+            this.type = type;
+            positions = new float2[num];
+            velocities = new float2[num];
+            this.temperature = temperature;
         }
     }
 
     void OnDrawGizmos()
     {
-        if (showSpawnBoundsGizmos && !Application.isPlaying)
-        {
-            Gizmos.color = new Color(1, 1, 0, 0.5f);
-            Gizmos.DrawWireCube(spawnCentre, Vector2.one * spawnSize);
-        }
+        if (!showSpawnBoundsGizmos || Application.isPlaying) return;
+
+        Gizmos.color = this.wireFrameColor;
+        Gizmos.DrawWireCube(spawnCentre, Vector2.one * spawnSize);
     }
 }

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
@@ -614,11 +614,11 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
             idx += spawnD.positions.Length;
             spawnerIdx++;
         }
-        
+
         // Fill empty space with disabled particles
-        if (idx+1 < maxParticles)
+        if (idx < maxParticles)
         {
-            Debug.Log($"Particle Spawner: maxParticles < numParticles to spawn; filling scene with disabled particles. maxParticles: {maxParticles}, numParticles: {idx+1}");
+            Debug.Log($"Particle Spawner: maxParticles < numParticles to spawn; filling scene with disabled particles. maxParticles: {maxParticles}, numParticles: {idx}");
             int numFill = maxParticles - idx - 1;
             ParticleSpawner.ParticleSpawnData spawnD = ParticleSpawner.GetSceneFill(numFill, boundsSize);
             for (int i = 0; i < spawnD.positions.Length; i++)

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
@@ -16,6 +16,7 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
     [Header("Simulation Settings")]
     public float timeScale = 1;
     public bool fixedTimeStep; // Enable for consistent simulation steps across different framerates, (limits smoothness to 120fps)
+    public int maxParticles;
     [Tooltip("Disable this to manually add obstacles to the simulation. If enabled, the obstacles will scanned via tags")]
     public bool scanForObstaclesOnStart = true;
     public int iterationsPerFrame;
@@ -149,12 +150,11 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
 
         targetInteractionRadius = interactionRadius;
         targetInteractionStrength = interactionStrength;
-        numParticles = 0;
+        numParticles = maxParticles;
         spawnDataArr = new ParticleSpawner.ParticleSpawnData[spawners.Length];
         for (int k = 0; k<spawners.Length; k++)
         {
             spawnDataArr[k] = spawners[k].GetSpawnData();
-            numParticles += spawnDataArr[k].positions.Length;
         }
 
         if (!manuallySelectFluidTypes)
@@ -581,19 +581,25 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
 
     void SetInitialBufferData(ParticleSpawner.ParticleSpawnData[] spawnData)
     {
-        int numP = 0;
         for (int k = 0; k < spawners.Length; k++)
         {
             spawnDataArr[k] = spawners[k].GetSpawnData();
-            numP += spawnDataArr[k].positions.Length;
         }
-        Particle[] allPoints = new Particle[numP];
+        Particle[] allPoints = new Particle[maxParticles];
         int idx = 0;
+        int spawnerIdx = 0;
 
         foreach (ParticleSpawner.ParticleSpawnData spawnD in spawnData)
         {
             for (int i = 0; i < spawnD.positions.Length; i++)
             {
+                // Early exit if we break max particle limit
+                if (idx + i >= maxParticles)
+                {
+                    Debug.LogWarning($"Particle Spawner: Hit max particle count! Current spawner index: {spawnerIdx}, Spawner particle offset: {i}");
+                    particleBuffer.SetData(allPoints);
+                    return;
+                }
                 Particle p = new Particle
                 {
                     position = spawnD.positions[i],
@@ -606,6 +612,35 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
                 allPoints[idx + i] = p;
             }
             idx += spawnD.positions.Length;
+            spawnerIdx++;
+        }
+        
+        // Fill empty space with disabled particles
+        if (idx+1 < maxParticles)
+        {
+            Debug.Log($"Particle Spawner: maxParticles < numParticles to spawn; filling scene with disabled particles. maxParticles: {maxParticles}, numParticles: {idx+1}");
+            int numFill = maxParticles - idx - 1;
+            ParticleSpawner.ParticleSpawnData spawnD = ParticleSpawner.GetSceneFill(numFill, boundsSize);
+            for (int i = 0; i < spawnD.positions.Length; i++)
+            {
+                // Early exit if we break max particle limit, shouldn't happen
+                if (idx + i >= maxParticles)
+                {
+                    Debug.LogWarning($"Particle Spawner: Hit max particle count during fill! Spawner particle offset: {i}");
+                    particleBuffer.SetData(allPoints);
+                    return;
+                }
+                Particle p = new Particle
+                {
+                    position = spawnD.positions[i],
+                    predictedPosition = spawnD.positions[i],
+                    velocity = spawnD.velocities[i],
+                    density = new float2(0, 0),
+                    temperature = spawnD.temperature,
+                    type = spawnD.type
+                };
+                allPoints[idx + i] = p;
+            }
         }
 
         particleBuffer.SetData(allPoints);

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
@@ -77,7 +77,7 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
 
     [Header("References")]
     public ComputeShader compute;
-    public ParticleSpawner spawner;
+    public ParticleSpawner[] spawners;
     public IParticleDisplay display;
 
     [Header("Obstacle Colliders")]
@@ -133,7 +133,7 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
 
     // State
     bool isPaused;
-    ParticleSpawner.ParticleSpawnData spawnData;
+    ParticleSpawner.ParticleSpawnData[] spawnDataArr;
     bool pauseNextFrame;
 
     public int numParticles { get; private set; }
@@ -149,8 +149,13 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
 
         targetInteractionRadius = interactionRadius;
         targetInteractionStrength = interactionStrength;
-        spawnData = spawner.GetSpawnData();
-        numParticles = spawnData.positions.Length;
+        numParticles = 0;
+        spawnDataArr = new ParticleSpawner.ParticleSpawnData[spawners.Length];
+        for (int k = 0; k<spawners.Length; k++)
+        {
+            spawnDataArr[k] = spawners[k].GetSpawnData();
+            numParticles += spawnDataArr[k].positions.Length;
+        }
 
         if (!manuallySelectFluidTypes)
         {
@@ -237,7 +242,7 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
         // Set buffer data
         fluidDataBuffer.SetData(fluidParamArr);
         ScalingFactorsBuffer.SetData(scalingFactorsArr);
-        SetInitialBufferData(spawnData);
+        SetInitialBufferData(spawnDataArr);
         uint[] atomicCounter = { 0, frameCounter++ };
         atomicCounterBuffer.SetData(atomicCounter);
 
@@ -574,22 +579,33 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
         compute.SetFloat("interactionInputRadius", interactionRadius);
     }
 
-    void SetInitialBufferData(ParticleSpawner.ParticleSpawnData spawnData)
+    void SetInitialBufferData(ParticleSpawner.ParticleSpawnData[] spawnData)
     {
-        Particle[] allPoints = new Particle[spawnData.positions.Length];
-
-        for (int i = 0; i < spawnData.positions.Length; i++)
+        int numP = 0;
+        for (int k = 0; k < spawners.Length; k++)
         {
-            Particle p = new Particle
+            spawnDataArr[k] = spawners[k].GetSpawnData();
+            numP += spawnDataArr[k].positions.Length;
+        }
+        Particle[] allPoints = new Particle[numP];
+        int idx = 0;
+
+        foreach (ParticleSpawner.ParticleSpawnData spawnD in spawnData)
+        {
+            for (int i = 0; i < spawnD.positions.Length; i++)
             {
-                position = spawnData.positions[i],
-                predictedPosition = spawnData.positions[i],
-                velocity = spawnData.velocities[i],
-                density = new float2(0, 0),
-                temperature = spawnData.temperature,
-                type = spawnData.type
-            };
-            allPoints[i] = p;
+                Particle p = new Particle
+                {
+                    position = spawnD.positions[i],
+                    predictedPosition = spawnD.positions[i],
+                    velocity = spawnD.velocities[i],
+                    density = new float2(0, 0),
+                    temperature = spawnD.temperature,
+                    type = spawnD.type
+                };
+                allPoints[idx + i] = p;
+            }
+            idx += spawnD.positions.Length;
         }
 
         particleBuffer.SetData(allPoints);
@@ -820,6 +836,14 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
             }
         }
 
+        if (spawners != null)
+        {
+            foreach (ParticleSpawner pSpawn in spawners)
+            {
+                pSpawn.OnDrawGizmos();
+            }
+        }
+
         if (Application.isPlaying)
         {
             Vector2 mousePos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
@@ -878,9 +902,9 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
     {
         isPaused = true;
         // Reset positions, the run single frame to get density etc (for debug purposes) and then reset positions again
-        SetInitialBufferData(spawnData);
+        SetInitialBufferData(spawnDataArr);
         RunSimulationStep();
-        SetInitialBufferData(spawnData);
+        SetInitialBufferData(spawnDataArr);
     }
 
     // These functions are for the fluid detector

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
@@ -152,6 +152,11 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
         targetInteractionStrength = interactionStrength;
         numParticles = maxParticles;
         spawnDataArr = new ParticleSpawner.ParticleSpawnData[spawners.Length];
+        if (spawners == null || spawners.Length == 0)
+        {
+            Debug.LogWarning("No particle spawners assigned. If this is unintended, please add at least one spawner in the inspector.");
+            return;
+        }
         for (int k = 0; k<spawners.Length; k++)
         {
             spawnDataArr[k] = spawners[k].GetSpawnData();

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
@@ -578,7 +578,6 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
     {
         Particle[] allPoints = new Particle[spawnData.positions.Length];
 
-        // FIXME defaulting some values
         for (int i = 0; i < spawnData.positions.Length; i++)
         {
             Particle p = new Particle
@@ -587,8 +586,8 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
                 predictedPosition = spawnData.positions[i],
                 velocity = spawnData.velocities[i],
                 density = new float2(0, 0),
-                temperature = 22.0f,
-                type = FluidType.Water // Or whatever default type you want};
+                temperature = spawnData.temperature,
+                type = spawnData.type
             };
             allPoints[i] = p;
         }

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
@@ -159,7 +159,7 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
         spawnDataArr = new ParticleSpawner.ParticleSpawnData[spawners.Length];
         if (spawners == null || spawners.Length == 0)
         {
-            Debug.LogWarning("No particle spawners assigned. If this is unintended, please add at least one spawner in the inspector.");
+            Debug.LogWarning("No particle spawners assigned. If this is unintended, please add at least one spawner in the inspector or enable the 'Scan for Particle Spawners on Start' option.");
             return;
         }
         for (int k = 0; k<spawners.Length; k++)

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
@@ -618,7 +618,7 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
         // Fill empty space with disabled particles
         if (idx < maxParticles)
         {
-            Debug.Log($"Particle Spawner: maxParticles < numParticles to spawn; filling scene with disabled particles. maxParticles: {maxParticles}, numParticles: {idx}");
+            Debug.Log($"Particle Spawner: maxParticles > numParticles to spawn; filling scene with disabled particles. maxParticles: {maxParticles}, numParticles: {idx}");
             int numFill = maxParticles - idx - 1;
             ParticleSpawner.ParticleSpawnData spawnD = ParticleSpawner.GetSceneFill(numFill, boundsSize);
             for (int i = 0; i < spawnD.positions.Length; i++)

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoSCounting.cs
@@ -19,6 +19,7 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
     public int maxParticles;
     [Tooltip("Disable this to manually add obstacles to the simulation. If enabled, the obstacles will scanned via tags")]
     public bool scanForObstaclesOnStart = true;
+    public bool scanForParticleSpawnersOnStart = true;
     public int iterationsPerFrame;
     public float globalEntropyRate = 1f;
     public float roomTemperature = 22f;
@@ -151,6 +152,10 @@ public class Simulation2DAoSCounting : MonoBehaviour, IFluidSimulation
         targetInteractionRadius = interactionRadius;
         targetInteractionStrength = interactionStrength;
         numParticles = maxParticles;
+
+        if (scanForParticleSpawnersOnStart){
+            spawners = FindObjectsByType<ParticleSpawner>(FindObjectsSortMode.None);
+        }
         spawnDataArr = new ParticleSpawner.ParticleSpawnData[spawners.Length];
         if (spawners == null || spawners.Length == 0)
         {

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
@@ -74,7 +74,7 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
 
     [Header("References")]
     public ComputeShader compute;
-    public ParticleSpawner spawner;
+    public ParticleSpawner[] spawners;
     public IParticleDisplay display;
 
     [Header("Obstacle Colliders")]
@@ -131,7 +131,7 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
 
     // State
     bool isPaused;
-    ParticleSpawner.ParticleSpawnData spawnData;
+    ParticleSpawner.ParticleSpawnData[] spawnDataArr;
     bool pauseNextFrame;
 
     public int numParticles { get; private set; }
@@ -160,8 +160,13 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
         CPUKernelAOS = new CPUParticleKernelAoS();
         targetInteractionRadius = interactionRadius;
         targetInteractionStrength = interactionStrength;
-        spawnData = spawner.GetSpawnData();
-        numParticles = spawnData.positions.Length;
+        numParticles = 0;
+        spawnDataArr = new ParticleSpawner.ParticleSpawnData[spawners.Length];
+        for (int k = 0; k < spawners.Length; k++)
+        {
+            spawnDataArr[k] = spawners[k].GetSpawnData();
+            numParticles += spawnDataArr[k].positions.Length;
+        }
 
         if (!manuallySelectFluidTypes)
         {
@@ -250,7 +255,7 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
         // Set buffer data
         fluidDataBuffer.SetData(fluidParamArr);
         ScalingFactorsBuffer.SetData(scalingFactorsArr);
-        SetInitialBufferData(spawnData);
+        SetInitialBufferData(spawnDataArr);
         uint[] atomicCounter = { 0, frameCounter++ };
         atomicCounterBuffer.SetData(atomicCounter);
 
@@ -672,22 +677,33 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
         compute.SetFloat("interactionInputRadius", interactionRadius);
     }
 
-    void SetInitialBufferData(ParticleSpawner.ParticleSpawnData spawnData)
+    void SetInitialBufferData(ParticleSpawner.ParticleSpawnData[] spawnData)
     {
-        Particle[] allPoints = new Particle[spawnData.positions.Length];
-
-        for (int i = 0; i < spawnData.positions.Length; i++)
+        int numP = 0;
+        for (int k = 0; k < spawners.Length; k++)
         {
-            Particle p = new Particle
+            spawnDataArr[k] = spawners[k].GetSpawnData();
+            numP += spawnDataArr[k].positions.Length;
+        }
+        Particle[] allPoints = new Particle[numP];
+        int idx = 0;
+
+        foreach (ParticleSpawner.ParticleSpawnData spawnD in spawnData)
+        {
+            for (int i = 0; i < spawnD.positions.Length; i++)
             {
-                position = spawnData.positions[i],
-                predictedPosition = spawnData.positions[i],
-                velocity = spawnData.velocities[i],
-                density = new float2(0, 0),
-                temperature = spawnData.temperature,
-                type = spawnData.type
-            };
-            allPoints[i] = p;
+                Particle p = new Particle
+                {
+                    position = spawnD.positions[i],
+                    predictedPosition = spawnD.positions[i],
+                    velocity = spawnD.velocities[i],
+                    density = new float2(0, 0),
+                    temperature = spawnD.temperature,
+                    type = spawnD.type
+                };
+                allPoints[idx + i] = p;
+            }
+            idx += spawnD.positions.Length;
         }
 
         particleBuffer.SetData(allPoints);
@@ -878,6 +894,15 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
             }
         }
 
+        // Draw spawners
+        if (spawners != null)
+        {
+            foreach (ParticleSpawner pSpawn in spawners)
+            {
+                pSpawn.OnDrawGizmos();
+            }
+        }
+
         if (Application.isPlaying)
         {
             Vector2 mousePos = Camera.main.ScreenToWorldPoint(Input.mousePosition);
@@ -930,9 +955,9 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
     {
         isPaused = true;
         // Reset positions, the run single frame to get density etc (for debug purposes) and then reset positions again
-        SetInitialBufferData(spawnData);
+        SetInitialBufferData(spawnDataArr);
         RunSimulationStep();
-        SetInitialBufferData(spawnData);
+        SetInitialBufferData(spawnDataArr);
     }
 
     // These functions are for the fluid detector

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
@@ -163,6 +163,11 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
         targetInteractionStrength = interactionStrength;
         numParticles = 0;
         spawnDataArr = new ParticleSpawner.ParticleSpawnData[spawners.Length];
+        if (spawners == null || spawners.Length == 0)
+        {
+            Debug.LogWarning("No particle spawners assigned. If this is unintended, please add at least one spawner in the inspector.");
+            return;
+        }
         for (int k = 0; k < spawners.Length; k++)
         {
             spawnDataArr[k] = spawners[k].GetSpawnData();

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
@@ -715,9 +715,9 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
         }
 
         // Fill empty space with disabled particles
-        if (idx + 1 < maxParticles)
+        if (idx < maxParticles)
         {
-            Debug.Log($"Particle Spawner: maxParticles < numParticles to spawn; filling scene with disabled particles. maxParticles: {maxParticles}, numParticles: {idx + 1}");
+            Debug.Log($"Particle Spawner: maxParticles < numParticles to spawn; filling scene with disabled particles. maxParticles: {maxParticles}, numParticles: {idx}");
             int numFill = maxParticles - idx - 1;
             ParticleSpawner.ParticleSpawnData spawnD = ParticleSpawner.GetSceneFill(numFill, boundsSize);
             for (int i = 0; i < spawnD.positions.Length; i++)

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
@@ -676,7 +676,6 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
     {
         Particle[] allPoints = new Particle[spawnData.positions.Length];
 
-        // FIXME defaulting some values
         for (int i = 0; i < spawnData.positions.Length; i++)
         {
             Particle p = new Particle
@@ -685,8 +684,8 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
                 predictedPosition = spawnData.positions[i],
                 velocity = spawnData.velocities[i],
                 density = new float2(0, 0),
-                temperature = 22.0f,
-                type = FluidType.Water // Or whatever default type you want};
+                temperature = spawnData.temperature,
+                type = spawnData.type
             };
             allPoints[i] = p;
         }

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
@@ -695,7 +695,7 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
                 // Early exit if we break max particle limit
                 if (idx + i >= maxParticles)
                 {
-                    Debug.LogWarning($"Particle Spawner: Hit max particle count! Current spawner index: {spawnerIdx}, Spawner particle offset: {i}");
+                    Debug.LogWarning($"Particle Spawner: Hit max particle count! Current spawner index: {spawnerIdx}; Spawner particle offset: {i}");
                     particleBuffer.SetData(allPoints);
                     return;
                 }
@@ -717,7 +717,7 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
         // Fill empty space with disabled particles
         if (idx < maxParticles)
         {
-            Debug.Log($"Particle Spawner: maxParticles < numParticles to spawn; filling scene with disabled particles. maxParticles: {maxParticles}, numParticles: {idx}");
+            Debug.Log($"Particle Spawner: maxParticles > numParticles to spawn; filling scene with disabled particles. maxParticles: {maxParticles}, numParticles: {idx}");
             int numFill = maxParticles - idx - 1;
             ParticleSpawner.ParticleSpawnData spawnD = ParticleSpawner.GetSceneFill(numFill, boundsSize);
             for (int i = 0; i < spawnD.positions.Length; i++)

--- a/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
+++ b/Fluid Simulation/Assets/Scripts/Sim_2D/Simulation2DAoS_CPUCSort.cs
@@ -16,6 +16,7 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
     [Header("Simulation Settings")]
     public float timeScale = 1;
     public bool fixedTimeStep; // Enable for consistent simulation steps across different framerates, (limits smoothness to 120fps)
+    public int maxParticles;
     [Tooltip("Disable this to manually add obstacles to the simulation. If enabled, the obstacles will scanned via tags")]
     public bool scanForObstaclesOnStart = true;
     public int iterationsPerFrame;
@@ -679,19 +680,25 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
 
     void SetInitialBufferData(ParticleSpawner.ParticleSpawnData[] spawnData)
     {
-        int numP = 0;
         for (int k = 0; k < spawners.Length; k++)
         {
             spawnDataArr[k] = spawners[k].GetSpawnData();
-            numP += spawnDataArr[k].positions.Length;
         }
-        Particle[] allPoints = new Particle[numP];
+        Particle[] allPoints = new Particle[maxParticles];
         int idx = 0;
+        int spawnerIdx = 0;
 
         foreach (ParticleSpawner.ParticleSpawnData spawnD in spawnData)
         {
             for (int i = 0; i < spawnD.positions.Length; i++)
             {
+                // Early exit if we break max particle limit
+                if (idx + i >= maxParticles)
+                {
+                    Debug.LogWarning($"Particle Spawner: Hit max particle count! Current spawner index: {spawnerIdx}, Spawner particle offset: {i}");
+                    particleBuffer.SetData(allPoints);
+                    return;
+                }
                 Particle p = new Particle
                 {
                     position = spawnD.positions[i],
@@ -704,6 +711,35 @@ public class Simulation2DAoS_CPUCSort : MonoBehaviour, IFluidSimulation
                 allPoints[idx + i] = p;
             }
             idx += spawnD.positions.Length;
+            spawnerIdx++;
+        }
+
+        // Fill empty space with disabled particles
+        if (idx + 1 < maxParticles)
+        {
+            Debug.Log($"Particle Spawner: maxParticles < numParticles to spawn; filling scene with disabled particles. maxParticles: {maxParticles}, numParticles: {idx + 1}");
+            int numFill = maxParticles - idx - 1;
+            ParticleSpawner.ParticleSpawnData spawnD = ParticleSpawner.GetSceneFill(numFill, boundsSize);
+            for (int i = 0; i < spawnD.positions.Length; i++)
+            {
+                // Early exit if we break max particle limit, shouldn't happen
+                if (idx + i >= maxParticles)
+                {
+                    Debug.LogWarning($"Particle Spawner: Hit max particle count during fill! Spawner particle offset: {i}");
+                    particleBuffer.SetData(allPoints);
+                    return;
+                }
+                Particle p = new Particle
+                {
+                    position = spawnD.positions[i],
+                    predictedPosition = spawnD.positions[i],
+                    velocity = spawnD.velocities[i],
+                    density = new float2(0, 0),
+                    temperature = spawnD.temperature,
+                    type = spawnD.type
+                };
+                allPoints[idx + i] = p;
+            }
         }
 
         particleBuffer.SetData(allPoints);


### PR DESCRIPTION
Moved Particle Spawner outside of simulation script, is now script-agnostic.
Updated Particle Spawner logic for both CSort and CPUCSort scripts.

Particle Spawner now accepts temperature and fluid type values.
Debug wirebox color may also be changed in the editor.
Particle Spawner(s) still need to be manually added to Fluid Simulation script array in editor, or else they won't be initialized.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Fluid simulation now offers enhanced customization with adjustable fluid type and temperature for particles.
  - The simulation supports multiple particle spawners, enabling more dynamic and complex scenarios.
  - Added a maximum particle limit to control the number of spawned particles.
  - Introduced automatic detection of particle spawners at the start of the simulation.

- **Refactor**
  - Improved processing logic to aggregate particle data from various sources.
  - Enhanced visual debugging tools for clearer representation of simulation bounds.
  - Updated methods for better handling of particle spawning and simulation resets.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->